### PR TITLE
Allow developer to set paused mode for tweens.

### DIFF
--- a/addons/ez_transitions/objects/plugin_singleton/plugin_singleton_script.gd
+++ b/addons/ez_transitions/objects/plugin_singleton/plugin_singleton_script.gd
@@ -6,6 +6,7 @@ extends CanvasLayer
 var plugin_transitions_enabled: bool = true
 var plugin_debug_mode: bool = true
 var plugin_speed_scale: float = 1.0
+var plugin_paused_mode: Tween.TweenPauseMode = Tween.TWEEN_PAUSE_PROCESS
 
 # Variables:
 var TRANSITION_OVERLAY: TransitionOverlay
@@ -41,6 +42,12 @@ func plugin_set_speed_scale(new_speed_scale: float) -> void:
 	plugin_speed_scale = new_speed_scale
 	if (plugin_debug_mode): # Checking if the plugin's debug mode is enabled.
 		print_rich("[color=red]Successfully updated EzTransitions speed scale. New value: %s" % str(new_speed_scale)) # Debug print.
+
+func plugin_set_paused_mode(new_paused_mode: Tween.TweenPauseMode) -> void:
+	# Sets the plugin's speed scale to the given value.
+	plugin_paused_mode = new_paused_mode
+	if (plugin_debug_mode): # Checking if the plugin's debug mode is enabled.
+		print_rich("[color=red]Successfully updated EzTransitions paused mode. New value: %s" % str(new_paused_mode)) # Debug print.
 	
 func set_easing(intro_ease: Tween.EaseType, outro_ease: Tween.EaseType) -> void:
 	# Updates the TransitionOverlay's intro and outro easing.

--- a/addons/ez_transitions/objects/transition_overlay/transition_overlay_script.gd
+++ b/addons/ez_transitions/objects/transition_overlay/transition_overlay_script.gd
@@ -72,6 +72,9 @@ func play_intro() -> void:
 	tween.set_ease(INTRO_EASE) # Updating the Tween's easing.
 	tween.set_trans(INTRO_TRANS) # Updating the Tween's transition.
 	
+	# Set paused mode for Tween.
+	tween.set_pause_mode(EzTransitions.plugin_paused_mode)
+	
 	# Tweening the "progress" property.
 	tween.tween_property(material, "shader_parameter/progress", 1.0 if (!REVERSE_INTRO) else 0.0, INTRO_DURATION / EzTransitions.plugin_speed_scale)
 	
@@ -100,6 +103,9 @@ func play_outro() -> void:
 	# Setting up the new Tween.
 	tween.set_ease(OUTRO_EASE) # Updating the Tween's easing.
 	tween.set_trans(OUTRO_TRANS) # Updating the Tween's transition.
+	
+	# Set paused mode for Tween.
+	tween.set_pause_mode(EzTransitions.plugin_paused_mode)
 	
 	# Tweening the "progress" property.
 	tween.tween_property(material, "shader_parameter/progress", 1.0 if (REVERSE_OUTRO) else 0.0, OUTRO_DURATION / EzTransitions.plugin_speed_scale)


### PR DESCRIPTION
### Issue
In my game, the player has the option to restart the game from the Pause menu. The Pause menu relies on the Godot 4 built-in `get_tree().paused` property to halt node processes. However, this approach inadvertently affects newly created Tween objects, preventing Tween animations in EzTransitions from completing.

### Proposed Solution
To address this issue, I have introduced a new plugin property named `plugin_paused_mode` of type `Tween.TweenPauseMode`. This property will be utilized by the `transition_overlay_script.gd` to dynamically set the Tween paused mode for both `play_intro()` and `play_outro()`.

### Implementation Details
- I have added the `plugin_paused_mode` property (type `Tween.TweenPauseMode`) to provide flexibility in managing Tween behavior.
- The `transition_overlay_script.gd` now utilizes this property to set the appropriate tween paused mode for both the `play_intro()` and `play_outro()` functions.

### Default Value
In consideration of common game development scenarios where scene switching continues even when the game is paused, I have set the default value of `plugin_paused_mode` to `Tween.TWEEN_PAUSE_PROCESS`. This default value allows Tweens to progress regardless of the `get_tree().paused` state.

### Additional Information
For more details on the `Tween.TweenPauseMode` enumeration, please refer to the Godot Engine documentation [here](https://docs.godotengine.org/en/stable/classes/class_tween.html#enum-tween-tweenpausemode).

## Testing
I have tested this implementation under various scenarios, including pausing and restarting the game from the Pause menu. The Tween animations now function as expected, providing a seamless transition experience.